### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/contoso-traders-provisioning-deployment.yml
+++ b/.github/workflows/contoso-traders-provisioning-deployment.yml
@@ -1,4 +1,6 @@
 name: contoso-traders-provisioning-deployment
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/github-cloudlabsuser-1367/cuddly-octo-broccoli/security/code-scanning/2](https://github.com/github-cloudlabsuser-1367/cuddly-octo-broccoli/security/code-scanning/2)

To fix the issue, add a `permissions` block to the root of the workflow file. This block will explicitly define the permissions for the `GITHUB_TOKEN`, limiting them to the least privileges required. Based on the workflow's operations, the `contents: read` permission is sufficient for most tasks, as the workflow does not appear to require write access to the repository.

The `permissions` block should be added immediately after the `name` field at the top of the workflow file. This ensures that the permissions apply to all jobs in the workflow unless overridden by job-specific permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
