### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/contoso-traders-app-deployment.yml
+++ b/.github/workflows/contoso-traders-app-deployment.yml
@@ -1,4 +1,6 @@
 name: contoso-traders-app-deployment
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/github-cloudlabsuser-1367/cuddly-octo-broccoli/security/code-scanning/1](https://github.com/github-cloudlabsuser-1367/cuddly-octo-broccoli/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root level of the workflow file. This block will explicitly define the permissions for the `GITHUB_TOKEN`, adhering to the principle of least privilege. Based on the workflow's operations, the minimal required permission is `contents: read`, which allows the workflow to read repository contents without granting write access.

The `permissions` block should be added immediately after the `name` field at the top of the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
